### PR TITLE
Commenting out swim hint changes

### DIFF
--- a/DeathRun/Patchers/BreathingPatcher.cs
+++ b/DeathRun/Patchers/BreathingPatcher.cs
@@ -194,10 +194,10 @@ namespace DeathRun.Patchers
             __result = Math.Min(3f, __result);
         }
     }
-
+//Commenting out swim hint changes as the "Out of Air" message gets stuck on screen 
     /**
      * "Swim to Surface" message obviously inappropriate when surface air is poisoned, plus it always seemed "odd" at 300m anyway.
-     */
+     
     [HarmonyPatch(typeof(uGUI_PopupMessage))]
     [HarmonyPatch("SetText")]
     internal class SwimToSurfacePatcher
@@ -229,14 +229,14 @@ namespace DeathRun.Patchers
     {
         /**
          * This just grabs the handle to the HintSwimToSurface object "so we can fuck with it later"
-         */
+         
         [HarmonyPostfix]
         public static void PostFix (HintSwimToSurface __instance)
         {
             SwimToSurfacePatcher.setHinter(__instance);
         }
     }
-
+    */
     /**
      * I find it endlessly irritating that it won't let you deploy the pump when you're on the surface. 
      * It's not "challenging gameplay" it's just a bad interface. So this fixes it.


### PR DESCRIPTION
Commenting out swim hint changes as the "Out of Air" message gets stuck on screen
This was tested by letting air run low/out then returning to either the pod or surface.
In both cases, the UI message remained for 3+ mins before testing stopped.
Note that the message never went away, testing just stopped.
The message can be cleared by save/load or another UI message.
